### PR TITLE
Support for ES6 template literals, preserve non-doc triple-quoted strings

### DIFF
--- a/PythonToJavascript/fixers/fixComments.py
+++ b/PythonToJavascript/fixers/fixComments.py
@@ -13,7 +13,12 @@ def fixComments( nodes ):
             text = node.value
             tquote_m = tquote_comment_rgx.match( text )
             if tquote_m:
-                node.value = "/*" + tquote_m.group( 2 ) + "*/"
+                if node.prev_sibling is None:
+                    # Comment string (use jsdoc double-star prefix)
+                    node.value = "/**" + tquote_m.group( 2 ) + "*/"
+                else:
+                    # Preserve other strings as template literals
+                    node.value = "`" + tquote_m.group( 2 ) + "`"
         else:
             text = node.prefix if white_space_rgx.sub( "", node.prefix ) else ""
             hash_m = hash_comment_rgx.match( text )


### PR DESCRIPTION
Only convert docstrings to comments (and use jsdoc double-star syntax), preserve other triple-quoted strings as ES6 template literals.

Converts:

```
def foo():
    """
    Documentation for foo.
    """
    runQuery("""
        SELECT * FROM foo
    """)
```

To:

```
function foo() {
    /**
    Documentation for foo.
    */
    runQuery(`
        SELECT * FROM foo
    `);
}
```